### PR TITLE
feat: add development base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,12 @@ jobs:
             for version in $(cat .versions); do
                 docker build --build-arg node_version=${version} -t quay.io/wealthwizards/ww-base-node:debian-${version} debian
             done
+      - run:
+          name : build-development-image
+          command: |
+            for version in $(cat .versions); do
+                docker build --build-arg node_version=${version} -t quay.io/wealthwizards/ww-base-node:development-${version} development
+            done
   buildAndDeploy:
     machine: true
     steps:
@@ -44,6 +50,18 @@ jobs:
                 docker tag quay.io/wealthwizards/ww-base-node:debian-${version} quay.io/wealthwizards/ww-base-node:debian-${major_version}
                 docker tag quay.io/wealthwizards/ww-base-node:debian-${version} quay.io/wealthwizards/ww-base-node:debian-latest
             done
+      - run:
+          name : build-development-image
+          command: |
+            for version in $(cat .versions); do
+                a=( ${version//./ } )
+                major_version=${a[0]}
+                minor_version=${a[1]}
+                docker build --build-arg node_version=${version} -t quay.io/wealthwizards/ww-base-node:development-${version} development
+                docker tag quay.io/wealthwizards/ww-base-node:development-${version} quay.io/wealthwizards/ww-base-node:development-${major_version}.${minor_version}
+                docker tag quay.io/wealthwizards/ww-base-node:development-${version} quay.io/wealthwizards/ww-base-node:development-${major_version}
+                docker tag quay.io/wealthwizards/ww-base-node:development-${version} quay.io/wealthwizards/ww-base-node:development-latest
+            done
       - deploy:
           name : docker-login
           command: |
@@ -69,6 +87,17 @@ jobs:
                 docker push quay.io/wealthwizards/ww-base-node:debian-${major_version}.${minor_version}
                 docker push quay.io/wealthwizards/ww-base-node:debian-${major_version}
                 docker push quay.io/wealthwizards/ww-base-node:debian-latest
+            done
+      - deploy:
+          name : push-development-image
+          command: |
+            for version in $(cat .versions); do
+                a=( ${version//./ } )
+                major_version=${a[0]}
+                minor_version=${a[1]}
+                docker push quay.io/wealthwizards/ww-base-node:development-${major_version}.${minor_version}
+                docker push quay.io/wealthwizards/ww-base-node:development-${major_version}
+                docker push quay.io/wealthwizards/ww-base-node:development-latest
             done
 workflows:
   version: 2

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,0 +1,4 @@
+ARG node_version
+FROM node:${node_version}-alpine
+ENV NODE_ENV=development
+RUN apk add --no-cache git

--- a/development/README.md
+++ b/development/README.md
@@ -1,0 +1,3 @@
+In development we've started using [Nx](https://nx.dev).
+
+Nx has the [concept of _affected_](https://nx.dev/latest/node/core-concepts/affected#affected), as in `yarn nx affected:test` or `yarn nx affected:lint`, this uses git to determine differences to a git branch (defaulted to `master`). These [_affected_ commands](https://nx.dev/latest/node/cli/affected) fail when using our default base image because git is not installed.


### PR DESCRIPTION
In development we've started using [Nx](https://nx.dev).

Nx has the [concept of _affected_](https://nx.dev/latest/node/core-concepts/affected#affected), as in `yarn nx affected:test` or `yarn nx affected:lint`, this uses git to determine differences to a git branch (defaulted to `master`). These [_affected_ commands](https://nx.dev/latest/node/cli/affected) fail when using our default base image because git is not installed.