### PR TITLE
feat: add pulumi and aws cli

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,4 +1,6 @@
 ARG node_version
 FROM node:${node_version}-alpine
 ENV NODE_ENV=development
-RUN apk add --no-cache git
+ENV PATH=$PATH:/root/.pulumi/bin
+RUN apk add --no-cache aws-cli curl git libc6-compat \
+ && curl -fsSL https://get.pulumi.com/ | sh


### PR DESCRIPTION
Add aws cli and pulumi cli to our base development image.
Locally the image goes from 133MB to 379MB.