### PR TITLE
Feat: Add Playwright WebKit browser to cypress docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,8 @@ jobs:
           name : build-cypress-image
           command: |
             for version in $(cat .versions-cypress); do
-                docker build --build-arg cypress_version=${version} -t quay.io/wealthwizards/ww-base-node:cypress-${version} cypress
+                cleaned_version=$(echo "${version}" | tr ':' '-')
+                docker build --build-arg cypress_version=${version} -t quay.io/wealthwizards/ww-base-node:cypress-${cleaned_version} cypress
             done
       - run:
           name : build-playwright-image
@@ -101,10 +102,11 @@ jobs:
           name : build-push-cypress-image
           command: |
             for version in $(cat .versions-cypress); do
-                docker build --build-arg cypress_version=${version} -t quay.io/wealthwizards/ww-base-node:cypress-${version} cypress
-                docker tag quay.io/wealthwizards/ww-base-node:cypress-${version} quay.io/wealthwizards/ww-base-node:cypress-${version}
-                docker tag quay.io/wealthwizards/ww-base-node:cypress-${version} quay.io/wealthwizards/ww-base-node:cypress-latest
-                docker push quay.io/wealthwizards/ww-base-node:cypress-${version}
+                cleaned_version=$(echo "${version}" | tr ':' '-')
+                docker build --build-arg cypress_version=${version} -t quay.io/wealthwizards/ww-base-node:cypress-${cleaned_version} cypress
+                docker tag quay.io/wealthwizards/ww-base-node:cypress-${cleaned_version} quay.io/wealthwizards/ww-base-node:cypress-${cleaned_version}
+                docker tag quay.io/wealthwizards/ww-base-node:cypress-${cleaned_version} quay.io/wealthwizards/ww-base-node:cypress-latest
+                docker push quay.io/wealthwizards/ww-base-node:cypress-${cleaned_version}
                 docker push quay.io/wealthwizards/ww-base-node:cypress-latest
             done
       - run:

--- a/.versions-cypress
+++ b/.versions-cypress
@@ -1,3 +1,3 @@
-node14.17.6-chrome100-ff98
-node16.17.0-chrome106
-node18.12.0-chrome107
+browsers:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
+browsers:node-20.10.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+included:cypress-13.6.2-node-20.10.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -1,5 +1,5 @@
 ARG cypress_version
-FROM cypress/browsers:${cypress_version}
+FROM cypress/${cypress_version}
 
 # Needed to add the hashicorp repo
 RUN apt-get update && \
@@ -17,3 +17,6 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
 RUN apt-get update && \
     apt-get install -y \
     vault
+
+# Build Add PlayWright WebKit browser
+RUN npx playwright install --with-deps webkit

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
     lsb-release \
     gnupg2 \
     software-properties-common \
-    git
+    git \
+    curl
 
 # Needed to get vault from hashicorp
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \


### PR DESCRIPTION
* Added Playwright WebKit browser to Cypress docker images
* Added ability to release both Cypress `included` and `browsers` images
* EOL for NodeJs < 18 in Cypress images